### PR TITLE
fix tilesize

### DIFF
--- a/example/raylib-tmx-example.c
+++ b/example/raylib-tmx-example.c
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
     InitWindow(screenWidth, screenHeight, "[raylib-tmx] example");
     SetTargetFPS(60);
 
-    tmx_map* map = LoadTMX("resources/desert.tmx");
+    tmx_map* map = LoadTMX(argv[1]);
     Vector2 position = {0, 0};
     //--------------------------------------------------------------------------------------
 

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -308,8 +308,8 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint) {
 
     srcRect.x  = tile->ul_x;
     srcRect.y  = tile->ul_y;
-    srcRect.width  = tile->tileset->tile_width;
-    srcRect.height = tile->tileset->tile_height;
+    srcRect.width  = tile->width;
+    srcRect.height = tile->height;
 
     // Find the image
     tmx_image *im = tile->image;


### PR DESCRIPTION
When a tileset has more than one object the drawing was displaying multiple objects.