### PR TITLE
Use tile->tilset->tile_width instead tile->width

### DIFF
--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -308,8 +308,8 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint) {
 
     srcRect.x  = tile->ul_x;
     srcRect.y  = tile->ul_y;
-    srcRect.width  = tile->width;
-    srcRect.height = tile->height;
+    srcRect.width  = tile->tileset->tile_width;
+    srcRect.height = tile->tileset->tile_height;
 
     // Find the image
     tmx_image *im = tile->image;


### PR DESCRIPTION
I have tried to build the example and get an Error:

`/Users/burakssen/dev/cpp_projects/raylib-tmx/src/../include/raylib-tmx.h:311:28: error: no member named 'width' in 'struct _tmx_tile'
    srcRect.width  = tile->width;
                     ~~~~  ^
/Users/burakssen/dev/cpp_projects/raylib-tmx/src/../include/raylib-tmx.h:312:28: error: no member named 'height' in 'struct _tmx_tile'
    srcRect.height = tile->height;
                     ~~~~  ^`
                     
and using tile->tileset->tile_width and tile->tileset->tile_height fixed the issue.