### PR TITLE
feature: DrawTMXObjectTile with flags and rotation capabilities

### DIFF
--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -324,12 +324,16 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint, int baseGid) {
     srcRect.height = (float)tile->tileset->tile_height;
 
     if (flags != 0) {
-	int is_horizontally_flipped = baseGid & TMX_FLIPPED_HORIZONTALLY;
-	if (is_horizontally_flipped != 0) srcRect.width = -fabs(srcRect.width);
-	int is_vertically_flipped   = baseGid & TMX_FLIPPED_VERTICALLY;
-	if (is_vertically_flipped   != 0) srcRect.height = -fabs(srcRect.height);
-	// TODO: Handle diagonal flip
-	// int is_diagonally_flipped   = gid & TMX_FLIPPED_DIAGONALLY;
+	if (baseGid & TMX_FLIPPED_DIAGONALLY) {
+            srcRect.width = -fabs(srcRect.width);
+            srcRect.height = -fabs(srcRect.height);
+	} else {
+            if (baseGid & TMX_FLIPPED_HORIZONTALLY) {
+		srcRect.width = -fabs(srcRect.width);
+	    } else if (baseGid & TMX_FLIPPED_VERTICALLY) {
+		srcRect.height = -fabs(srcRect.height);
+	    }
+	}
     }
 
     // Find the image

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -47,7 +47,7 @@ Color ColorFromTMX(uint32_t color);                                 // Convert a
 void DrawTMX(tmx_map *map, int posX, int posY, Color tint);         // Render the given Tiled map to the screen
 void DrawTMXLayers(tmx_map *map, tmx_layer *layers, int posX, int posY, Color tint); // Render all the given map layers to the screen
 void DrawTMXLayer(tmx_map *map, tmx_layer *layer, int posX, int posY, Color tint); // Render a single map layer on the screen
-void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint);   // Render the given tile to the screen
+void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint, int baseGid);   // Render the given tile to the screen
 
 #ifdef __cplusplus
 }
@@ -255,12 +255,15 @@ void DrawTMXLayerObjects(tmx_map *map, tmx_object_group *objgr, int posX, int po
 		                     (float)head->height / 2.0f,
 		                     color);
                     break;
-                case OT_TILE: {
-                    int gid = head->content.gid;
-                    if (map->tiles[gid] != NULL) {
-                        DrawTMXTile(map->tiles[gid], (int)dest.x, (int)(dest.y - dest.height), tint);
-                    }
-                } break;
+		}
+		case OT_TILE: {
+		    int baseGid = head->content.gid;
+                    int gid = baseGid & TMX_FLIP_BITS_REMOVAL;
+		    if (map->tiles[gid] != NULL) {
+                        DrawTMXTile(map->tiles[gid], (int)dest.x, (int)(dest.y - dest.height), tint, baseGid);
+		    }
+		    break;
+                }
                 case OT_TEXT: {
                     tmx_text* text = head->content.text;
                     Color textColor = ColorFromTMX(text->color);
@@ -299,12 +302,13 @@ void DrawTMXLayerImage(tmx_image *image, int posX, int posY, Color tint) {
  * @param posY The Y position of the tile.
  * @param tint How to tint the tile when rendering.
  */
-void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint) {
+void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint, int baseGid) {
     Texture* image = NULL;
     Rectangle srcRect;
     Vector2 position;
     position.x = (float)posX;
     position.y = (float)posY;
+    int flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
 
 #ifdef RAYLIB_TMX_SUPPORT_ANIMATIONS
     // TODO: Process the animation https://github.com/baylej/tmx/pull/64
@@ -318,6 +322,9 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint) {
     srcRect.y      = (float)tile->ul_y;
     srcRect.width  = (float)tile->tileset->tile_width;
     srcRect.height = (float)tile->tileset->tile_height;
+
+    if (flags != 0) {
+    }
 
     // Find the image
     tmx_image *im = tile->image;
@@ -356,7 +363,7 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
                         DrawTMXTile(map->tiles[gid],
 			           (int)((unsigned int)posX + x * ts->tile_width),
 				   (int)((unsigned int)posY + y * ts->tile_height),
-			           newTint);
+			           newTint, baseGid);
                     }
                 }
             }
@@ -373,7 +380,7 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
 			DrawTMXTile(map->tiles[gid],
 			           (int)((unsigned int)posX + x * ts->tile_width),
 				   (int)((unsigned int)posY + y * ts->tile_height),
-			           newTint);
+			           newTint, baseGid);
                     }
                 }
             }
@@ -390,7 +397,7 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
 			DrawTMXTile(map->tiles[gid],
 			           (int)((unsigned int)posX + x * ts->tile_width),
 				   (int)((unsigned int)posY + y * ts->tile_height),
-			           newTint);
+			           newTint, baseGid);
                     }
                 }
             }
@@ -407,7 +414,7 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
 			DrawTMXTile(map->tiles[gid],
 			           (int)((unsigned int)posX + x * ts->tile_width),
 				   (int)((unsigned int)posY + y * ts->tile_height),
-			           newTint);
+			           newTint, baseGid);
                     }
                 }
             }

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -257,15 +257,13 @@ void DrawTMXLayerObjects(tmx_map *map, tmx_object_group *objgr, int posX, int po
 		                     (float)head->height / 2.0f,
 		                     color);
                     break;
-		}
 		case OT_TILE: {
 		    int baseGid = head->content.gid;
                     int gid = baseGid & TMX_FLIP_BITS_REMOVAL;
 		    if (map->tiles[gid] != NULL) {
                         DrawTMXTile(map->tiles[gid], (int)dest.x, (int)(dest.y - dest.height), tint, baseGid);
 		    }
-		    break;
-                }
+		} break;
                 case OT_TEXT: {
                     tmx_text* text = head->content.text;
                     Color textColor = ColorFromTMX(text->color);
@@ -330,6 +328,8 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint, int baseGid) {
 	if (is_horizontally_flipped != 0) srcRect.width = -fabs(srcRect.width);
 	int is_vertically_flipped   = baseGid & TMX_FLIPPED_VERTICALLY;
 	if (is_vertically_flipped   != 0) srcRect.height = -fabs(srcRect.height);
+	// TODO: Handle diagonal flip
+	// int is_diagonally_flipped   = gid & TMX_FLIPPED_DIAGONALLY;
     }
 
     // Find the image
@@ -362,8 +362,6 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
                 for (unsigned int x = 0; x < map->width; x++) {
                     baseGid = layer->content.gids[(y * map->width) + x];
                     gid = (baseGid) & TMX_FLIP_BITS_REMOVAL;
-                    // TODO: Add the flags of the tile to Draw.
-                    // flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
                     if (map->tiles[gid] != NULL) {
                         ts = map->tiles[gid]->tileset;
                         DrawTMXTile(map->tiles[gid],
@@ -379,8 +377,6 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
                 for (unsigned int x = 0; x < map->width; x++) {
                     baseGid = layer->content.gids[(y * map->width) + x];
                     gid = (baseGid) & TMX_FLIP_BITS_REMOVAL;
-                    // TODO: Add the flags of the tile to Draw.
-                    // flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
                     if (map->tiles[gid] != NULL) {
                         ts = map->tiles[gid]->tileset;
 			DrawTMXTile(map->tiles[gid],
@@ -396,8 +392,6 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
                 for (unsigned int x = map->width - 1; x >= 0; x--) {
                     baseGid = layer->content.gids[(y * map->width) + x];
                     gid = (baseGid) & TMX_FLIP_BITS_REMOVAL;
-                    // TODO: Add the flags of the tile to Draw.
-                    // flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
                     if (map->tiles[gid] != NULL) {
                         ts = map->tiles[gid]->tileset;
 			DrawTMXTile(map->tiles[gid],
@@ -413,8 +407,6 @@ void DrawTMXLayerTiles(tmx_map *map, tmx_layer *layer, int posX, int posY, Color
                 for (unsigned int x = map->width - 1; x >= 0; x--) {
                     baseGid = layer->content.gids[(y * map->width) + x];
                     gid = (baseGid) & TMX_FLIP_BITS_REMOVAL;
-                    // TODO: Add the flags of the tile to Draw.
-                    // flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
                     if (map->tiles[gid] != NULL) {
                         ts = map->tiles[gid]->tileset;
 			DrawTMXTile(map->tiles[gid],

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -33,6 +33,8 @@
 #ifndef INCLUDE_RAYLIB_TMX_H_
 #define INCLUDE_RAYLIB_TMX_H_
 
+#include <math.h>
+
 #include "raylib.h" // NOLINT
 #include "tmx.h" // NOLINT
 
@@ -324,6 +326,10 @@ void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint, int baseGid) {
     srcRect.height = (float)tile->tileset->tile_height;
 
     if (flags != 0) {
+	int is_horizontally_flipped = baseGid & TMX_FLIPPED_HORIZONTALLY;
+	if (is_horizontally_flipped != 0) srcRect.width = -fabs(srcRect.width);
+	int is_vertically_flipped   = baseGid & TMX_FLIPPED_VERTICALLY;
+	if (is_vertically_flipped   != 0) srcRect.height = -fabs(srcRect.height);
     }
 
     // Find the image


### PR DESCRIPTION
Hello. First of all, sorry for the linting, editing the code is pure hell, and I don't know what to do, if it pleases, take a time to fix the lint if it bothers you, because no matter what I do, when moving to upstream it gets ugly.

But last not not least, I have allowed the drawing of flipped tiles in horizontal and vertical, and fixed a bug that if an object with tile was using that capabilities, it would crashes due to trying to accessing a random position on memory.

Feel free to question anything, but basically, I've noticed that when a flag is not present, the following operations 

is_horizontally_flipped = baseGid & TMX_FLIPPED_HORIZONTALLY;
is_vertically_flipped   = baseGid & TMX_FLIPPED_VERTICALLY;
int is_diagonally_flipped   = gid & TMX_FLIPPED_DIAGONALLY;

will default to zero, and by this point, I've produced the logic to enable the flip of tiles.

I've tested only with objects, and not with tiles itself but I think it will work. 

Thanks!