### PR TITLE
chore: object alignment based calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,22 @@ void DrawTMXLayer(tmx_map *map, tmx_layer *layers, int posX, int posY, Color tin
 void DrawTMXTile(tmx_tile* tile, int posX, int posY, Color tint);
 void DrawTMXObjectTile(tmx_tile* tile, int baseGid, Rectangle destRect, float rotation, Color tint);
 
-typedef union {
-    Rectangle rect;
-    Vector2   point;
-    struct {
-        double** points;
-        int count;
-    } polygon;
+typedef struct {
+    enum {
+        COLLISION_RECT,
+        COLLISION_POINT,
+        COLLISION_POLYGON,
+        COLLISION_POLYLINE,
+        COLLISION_ELLIPSE
+    } type;
+    union {
+        Rectangle rect;
+        Vector2   point;
+        struct {
+            double** points;
+            int count;
+        } polygon;
+    };
 } RaylibTMXCollision;
 
 typedef void (*tmx_collision_functor)(tmx_object *object, RaylibTMXCollision collision, void* userdata);

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -741,16 +741,16 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                     int baseGid      = object->content.gid;
                     unsigned int gid = baseGid & TMX_FLIP_BITS_REMOVAL;
                     tmx_tile* tile   = map->tiles[gid];
+                    if (!tile) {
+                        callback(object, raylibCollision, userdata);
+                        continue;
+                    }
                     int flags                  = baseGid & ~TMX_FLIP_BITS_REMOVAL;
                     int is_diagonally_fliped   = baseGid & TMX_FLIPPED_DIAGONALLY;
                     int is_vertically_fliped   = baseGid & TMX_FLIPPED_VERTICALLY;
                     int is_horizontally_fliped = {
                         (int)((unsigned int)baseGid & TMX_FLIPPED_HORIZONTALLY)
                     };
-                    if (!tile) {
-                        callback(object, raylibCollision, userdata);
-                        continue;
-                    }
                     switch (tile->tileset->objectalignment)
                     {
                         // TODO: Rotated collisions shall be handled here

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -776,12 +776,12 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                                 }
                             } break;
                             case OA_NONE:
-                            case OA_BOTTOMLEFT: { /* TILED DEFAULT */
+                            case OA_BOTTOMLEFT: /* TILED DEFAULT */ {
                                 if (is_horizontally_fliped) {
                                     copy.x += object->width - collision->width;
                                 }
                                 if (is_vertically_fliped) {
-                                    copy.y = object->y - (collision->y + collision->height);
+                                    copy.y += object->height - collision->height;
                                 }
                             } break;
                             case OA_TOP:         /* TODO */ break;

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -500,7 +500,9 @@ void DrawTMXObjectTile(tmx_tile* tile, int baseGid, Rectangle destRect, float ro
 
     int flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
     if  (flags) {
-        int is_horizontally_fliped = (int)((unsigned int)baseGid & TMX_FLIPPED_HORIZONTALLY);
+        int is_horizontally_fliped = {
+            (int)((unsigned int)baseGid & TMX_FLIPPED_HORIZONTALLY)
+        };
         if (is_horizontally_fliped) {
 		    srcRect.width = (float) -fabs(srcRect.width);
 	    }
@@ -724,6 +726,12 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                     int baseGid      = object->content.gid;
                     unsigned int gid = baseGid & TMX_FLIP_BITS_REMOVAL;
                     tmx_tile* tile   = map->tiles[gid];
+                    int flags                  = baseGid & ~TMX_FLIP_BITS_REMOVAL;
+                    int is_diagonally_fliped   = baseGid & TMX_FLIPPED_DIAGONALLY;
+                    int is_vertically_fliped   = baseGid & TMX_FLIPPED_VERTICALLY;
+                    int is_horizontally_fliped = {
+                        (int)((unsigned int)baseGid & TMX_FLIPPED_HORIZONTALLY)
+                    };
                     if (!tile) {
                         callback(object, raylibCollision, userdata);
                         continue;
@@ -753,6 +761,26 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                         tmx_object copy = *collision;
                         copy.x += object->x;
                         copy.y += object->y;
+                        switch (tile->tileset->objectalignment)
+                        {
+                            case OA_TOPLEFT:  /*RAYLIB DEFAULT*/  break;
+                            case OA_NONE:
+                            case OA_BOTTOMLEFT: { /* TILED DEFAULT */
+                                if (is_horizontally_fliped) {
+                                    copy.x += object->width - collision->width;
+                                }
+                                if (is_vertically_fliped) {
+                                    copy.y = object->y - (collision->y + collision->height);
+                                }
+                            } break;
+                            case OA_TOP:         /* TODO */ break;
+                            case OA_LEFT:        /* TODO */ break;
+                            case OA_BOTTOM:      /* TODO */ break;
+                            case OA_RIGHT:       /* TODO */ break;
+                            case OA_TOPRIGHT:    /* TODO */ break;
+                            case OA_BOTTOMRIGHT: /* TODO */ break;
+                            case OA_CENTER:      /* TODO */ break;
+                        }
                         callback(collision, HandleTMXCollision(&copy), userdata);
                     } while ((collision = collision->next));
                 } while ((object = object->next));

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -733,7 +733,9 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                         case OA_TOPLEFT: /*RAYLIB DEFAULT*/ break;
                         case OA_NONE:
                         case OA_BOTTOMLEFT: { /* TILED DEFAULT */
-                            raylibCollision.rect.y -= (float) object->height;
+                            if (raylibCollision.type == COLLISION_RECT) {
+                                raylibCollision.rect.y -= (float) object->height;
+                            }
                         } break;
                         case OA_TOP:         /* TODO */ break;
                         case OA_LEFT:        /* TODO */ break;

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -49,13 +49,21 @@ typedef struct AnimationState {
     float frameCounter;
 } AnimationState;
 
-typedef union {
-    Rectangle rect;
-    Vector2   point;
-    struct {
-        double** points;
-        int count;
-    } polygon;
+typedef struct {
+    enum {
+        COLLISION_RECT,
+        COLLISION_POINT,
+        COLLISION_POLYGON,
+        COLLISION_ELLIPSE
+    } type;
+    union {
+        Rectangle rect;
+        Vector2   point;
+        struct {
+            double** points;
+            int count;
+        } polygon;
+    };
 } RaylibTMXCollision;
 
 typedef void (*tmx_collision_functor)(tmx_object *object, RaylibTMXCollision collision, void* userdata);
@@ -633,6 +641,7 @@ RaylibTMXCollision HandleTMXCollision(tmx_object* object) {
     {
 	    case OT_SQUARE:
 	    case OT_TILE: {
+            collision.type = COLLISION_RECT;
             collision.rect = (Rectangle) {
                 .x      = (float) object->x,
                 .y      = (float) object->y,
@@ -641,6 +650,7 @@ RaylibTMXCollision HandleTMXCollision(tmx_object* object) {
             };
 	    } break;
         case OT_POINT: {
+            collision.type  = COLLISION_POINT;
             collision.point = (Vector2) {
                 .x = (float)object->x,
                 .y = (float)object->y
@@ -648,10 +658,12 @@ RaylibTMXCollision HandleTMXCollision(tmx_object* object) {
         } break;
         case OT_POLYLINE:
         case OT_POLYGON: {
+            collision.type  = COLLISION_POLYGON;
             collision.polygon.points = object->content.shape->points;
             collision.polygon.count  = object->content.shape->points_len;
         } break;
         case OT_ELLIPSE: {
+            collision.type = COLLISION_ELLIPSE;
             collision.rect = (Rectangle) {
                 .x         = (float) (object->x + object->width  / 2.0f),
                 .y         = (float) (object->y + object->height / 2.0f),

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -763,7 +763,18 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                         copy.y += object->y;
                         switch (tile->tileset->objectalignment)
                         {
-                            case OA_TOPLEFT:  /*RAYLIB DEFAULT*/  break;
+                            case OA_TOPLEFT: /*RAYLIB DEFAULT*/ {
+                                if (is_horizontally_fliped) {
+                                    int objectXOffset    = object->x + object->width;
+                                    int collisionXOffset = collision->x + collision->width;
+                                    copy.x = objectXOffset - collisionXOffset;
+                                }
+                                if (is_vertically_fliped) {
+                                    int objectYOffset    = object->y + object->height;
+                                    int collisionYOffset = collision->y + collision->height;
+                                    copy.y = objectYOffset - collisionYOffset;
+                                }
+                            } break;
                             case OA_NONE:
                             case OA_BOTTOMLEFT: { /* TILED DEFAULT */
                                 if (is_horizontally_fliped) {

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -54,6 +54,7 @@ typedef struct {
         COLLISION_RECT,
         COLLISION_POINT,
         COLLISION_POLYGON,
+        COLLISION_POLYLINE,
         COLLISION_ELLIPSE
     } type;
     union {
@@ -660,7 +661,7 @@ RaylibTMXCollision HandleTMXCollision(tmx_object* object) {
         } break;
         case OT_POLYLINE:
         case OT_POLYGON: {
-            collision.type  = COLLISION_POLYGON;
+            collision.type = (object->obj_type == OT_POLYGON) ? COLLISION_POLYGON : COLLISION_POLYLINE;
             collision.polygon.points = object->content.shape->points;
             collision.polygon.count  = object->content.shape->points_len;
         } break;

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -467,13 +467,28 @@ void DrawTMXTile(tmx_tile* tile, unsigned int baseGid, int posX, int posY, Color
 void DrawTMXObjectTile(tmx_tile* tile, int baseGid, Rectangle destRect, float rotation, Color tint) {
     Texture* image = NULL;
     Vector2 origin = {0};
-    destRect.y     = destRect.y - destRect.height;
     Rectangle srcRect = (Rectangle) {
         .x      = (float)tile->ul_x,
         .y      = (float)tile->ul_y,
         .width  = (float)tile->width,
         .height = (float)tile->height
     };
+
+    switch (tile->tileset->objectalignment)
+    {
+        case OA_TOPLEFT: /*RAYLIB DEFAULT*/ break;
+        case OA_NONE:
+        case OA_BOTTOMLEFT: { /* TILED DEFAULT */
+            destRect.y -= destRect.height;
+        } break;
+        case OA_TOP:         /* TODO */ break;
+        case OA_LEFT:        /* TODO */ break;
+        case OA_BOTTOM:      /* TODO */ break;
+        case OA_RIGHT:       /* TODO */ break;
+        case OA_TOPRIGHT:    /* TODO */ break;
+        case OA_BOTTOMRIGHT: /* TODO */ break;
+        case OA_CENTER:      /* TODO */ break;
+    }
 
     int flags = baseGid & ~TMX_FLIP_BITS_REMOVAL;
     if  (flags) {

--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -709,6 +709,20 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                             tmx_object copy = *collision;
                             copy.x += (x * tile->width);
                             copy.y += (y * tile->height);
+                            switch (tile->tileset->objectalignment)
+                            {
+                                // TODO: Rotated collisions shall be handle here
+                                case OA_TOPLEFT: /*RAYLIB DEFAULT */ /*TODO*/ break;
+                                case OA_NONE:
+                                case OA_BOTTOMLEFT:  /* TILED DEFAULT */ /* TODO */  break;
+                                case OA_TOP:         /* TODO */ break;
+                                case OA_LEFT:        /* TODO */ break;
+                                case OA_BOTTOM:      /* TODO */ break;
+                                case OA_RIGHT:       /* TODO */ break;
+                                case OA_TOPRIGHT:    /* TODO */ break;
+                                case OA_BOTTOMRIGHT: /* TODO */ break;
+                                case OA_CENTER:      /* TODO */ break;
+                            }
                             callback(collision, HandleTMXCollision(&copy), userdata);
                         } while ((collision = collision->next));
                     }
@@ -739,9 +753,10 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                     }
                     switch (tile->tileset->objectalignment)
                     {
+                        // TODO: Rotated collisions shall be handled here
                         case OA_TOPLEFT: /*RAYLIB DEFAULT*/ break;
                         case OA_NONE:
-                        case OA_BOTTOMLEFT: { /* TILED DEFAULT */
+                        case OA_BOTTOMLEFT: /* TILED DEFAULT */ {
                             if (raylibCollision.type == COLLISION_RECT) {
                                 raylibCollision.rect.y -= (float) object->height;
                             }
@@ -764,6 +779,7 @@ void CollisionsTMXForeach(tmx_map *map, tmx_collision_functor callback, void* us
                         copy.y += object->y;
                         switch (tile->tileset->objectalignment)
                         {
+                            // TODO: Rotated collisions shall be handled here
                             case OA_TOPLEFT: /*RAYLIB DEFAULT*/ {
                                 if (is_horizontally_fliped) {
                                     int objectXOffset    = object->x + object->width;


### PR DESCRIPTION
Hello. 

While messing with rotations and tinkering whit tiled and tmx documentation I've found the object-alignment property:

https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tmx-tileset

> When unspecified, tile objects use bottomleft in orthogonal mode and bottom in isometric mode. (since 1.4)

https://libtmx.readthedocs.io/en/latest/datastructure.html#c.tmx_obj_alignment

> Controls the alignment of tiles. When unspecified, tile objects use OA_BOTTOMLEFT in orthogonal mode and OA_BOTTOM in isometric mode (see [tmx_map_orient](https://libtmx.readthedocs.io/en/latest/datastructure.html#c.tmx_map_orient)).

This helped me to discover the reason for lots of crazy math going on.

This pr start to handle those calculations based in this property. I have added some for OA_TOPLEFT since it is the raylib default way to render and in some cases simplify the calculations because none is need, like in the case of collisions position. 

I've also added an enum to RaylibTMXCollision since this simplifies some checks, as it is possible to see in the examples. 
I've move an calculation on RaylibTMXCollision rects as well, since those was specific to OA_BOTTOMLEFT case and added it outside HandleTMXCollision function.

This was kinda unplanned but a nice discovery. Let me know what you think.