### PR TITLE
feat: LoadTMXFromMemory

### DIFF
--- a/include/raylib-tmx.h
+++ b/include/raylib-tmx.h
@@ -154,7 +154,6 @@ void* MemReallocTMX(void* address, size_t len) {
  * @return A TMX Tiled map object pointer.
  *
  * @see UnloadTMX()
- * @todo Add LoadTMXFromMemory() to allow loading through a buffer: https://github.com/baylej/tmx/pull/58
  */
 tmx_map* LoadTMX(const char* fileName) {
     // Register the TMX callbacks.
@@ -171,16 +170,33 @@ tmx_map* LoadTMX(const char* fileName) {
     }
     TraceLog(LOG_INFO, "TMX: Loaded %ix%i map", map->width, map->height);
     return map;
+}
 
-    // TODO: Load using a buffer instead: https://github.com/baylej/tmx/pull/58
-    // const char* fileText = LoadFileText(fileName);
-    // tmx_map* map = tmx_load_buffer_path(fileText, TextLength(fileText), fileName);
-    // if (!map) {
-    //     TraceLog(LOG_ERROR, "TMX: Failed to load TMX file %s", fileName);
-    //     return NULL;
-    // }
-    // TraceLog(LOG_INFO, "TMX: Loaded %ix%i map", map->width, map->height);
-    // return map;
+/**
+ * Loads given .tmx Tiled file.
+ *
+ * @param fileName The .tmx file to load.
+ *
+ * @return A TMX Tiled map object pointer.
+ *
+ * @see UnloadTMX()
+ */
+tmx_map* LoadTMXFromMemory(const char* fileName) {
+    // Register the TMX callbacks.
+    tmx_alloc_func = MemReallocTMX;
+    tmx_free_func = MemFree;
+    tmx_img_load_func = LoadTMXImage;
+	tmx_img_free_func = UnloadTMXImage;
+
+    const char* fileText = LoadFileText(fileName);
+    int textLenght = (int)TextLength(fileText);
+    tmx_map* map = tmx_load_buffer(fileText, textLenght);
+    if (!map) {
+        TraceLog(LOG_ERROR, "TMX: Failed to load TMX file %s", fileName);
+        return NULL;
+    }
+    TraceLog(LOG_INFO, "TMX: Loaded %ix%i map", map->width, map->height);
+    return map;
 }
 
 /**

--- a/test/raylib-tmx-test.c
+++ b/test/raylib-tmx-test.c
@@ -5,16 +5,57 @@
 #define RAYLIB_TMX_IMPLEMENTATION
 #include "raylib-tmx.h"
 
-void trace(const char* text) {
+void RaylibTMXTrace(const char* text) {
     TraceLog(LOG_INFO, "================================");
     TraceLog(LOG_INFO, text);
     TraceLog(LOG_INFO, "================================");
 }
 
+Texture* AssertTMXTexture(tmx_map* map)
+{
+    assert(map->ts_head != NULL);
+    assert(map->ts_head->tileset != NULL);
+    tmx_tileset* tileset = map->ts_head->tileset;
+    Texture *image = NULL;
+    if (tileset->image->resource_image) {
+        image = (Texture*) tileset->image->resource_image;
+        if (IsTextureValid(*image)) return image;
+    }
+
+    assert(tileset->tiles != NULL);
+    tmx_tile* tile = tileset->tiles;
+    if (tile->image) {
+        if (tile->image->resource_image) {
+            image = (Texture*) tile->image->resource_image;
+            if (IsTextureValid(*image)) return image;
+        }
+    }
+
+    return NULL;
+}
+
+void AssertRenderOrder(tmx_map* map)
+{
+    RaylibTMXTrace("Testing Render Order");
+    const int orders[] = {R_NONE, R_RIGHTDOWN, R_RIGHTUP, R_LEFTDOWN, R_LEFTUP};
+    const char *labels[] = {"R_NONE", "R_RIGHTDOWN", "R_RIGHTUP", "R_LEFTDOWN", "R_LEFTUP"};
+    for (size_t i = 0; i < sizeof(orders)/sizeof(orders[0]); i++) {
+	    RaylibTMXTrace(TextFormat("Draw %s", labels[i]));
+	    map->renderorder = (enum tmx_map_renderorder) orders[i];
+	    BeginDrawing();
+	    {
+            ClearBackground(RAYWHITE);
+            DrawTMX(map, 10, 10, WHITE);
+            DrawTMXLayer(map, map->ly_head, 10, 10, WHITE);
+	    }
+	    EndDrawing();
+    }
+}
+
 int main(int argc, char *argv[]) {
     // Initialization
     SetTraceLogLevel(LOG_ALL);
-    trace("raylib-tmx-test");
+    RaylibTMXTrace("raylib-tmx-test");
 
     SetConfigFlags(FLAG_WINDOW_HIDDEN);
     InitWindow(640, 480, "[raylib-tmx] tests");
@@ -25,27 +66,30 @@ int main(int argc, char *argv[]) {
     const char* dir = GetDirectoryPath(argv[0]);
     assert(ChangeDirectory(dir));
 
-    tmx_map* map = LoadTMX("resources/desert.tmx");
+    tmx_map* map = NULL;
+    map = LoadTMX("resources/desert.tmx");
     assert(map != NULL);
+    assert(AssertTMXTexture(map) != NULL);
+    UnloadTMX(map);
+    map = NULL;
+    assert(map == NULL);
+    map = LoadTMXFromMemory("resources/desert.tmx");
+    assert(map != NULL);
+    assert(AssertTMXTexture(map) == NULL);
+    UnloadTMX(map);
+    map = NULL;
+    assert(map == NULL);
+    ChangeDirectory("resources");
+    map = LoadTMXFromMemory("desert.tmx");
+    ChangeDirectory(GetApplicationDirectory());
+    assert(AssertTMXTexture(map) != NULL);
 
-    const int orders[] = {R_NONE, R_RIGHTDOWN, R_RIGHTUP, R_LEFTDOWN, R_LEFTUP};
-    const char *labels[] = {"R_NONE", "R_RIGHTDOWN", "R_RIGHTUP", "R_LEFTDOWN", "R_LEFTUP"};
-    for (size_t i = 0; i < sizeof(orders)/sizeof(orders[0]); i++) {
-	trace(TextFormat("Draw %s", labels[i]));
-	map->renderorder = (enum tmx_map_renderorder) orders[i];
-	BeginDrawing();
-	{
-            ClearBackground(RAYWHITE);
-            DrawTMX(map, 10, 10, WHITE);
-            DrawTMXLayer(map, map->ly_head, 10, 10, WHITE);
-	}
-	EndDrawing();
-    }
+    AssertRenderOrder(map);
 
     UnloadTMX(map);
 
     CloseWindow();
-    trace("raylib-tmx tests succesful");
+    RaylibTMXTrace("raylib-tmx tests succesful");
 
     return 0;
 }


### PR DESCRIPTION
Hello. I took the liberty to implement this TODO and notice some things. 

Looking at https://github.com/baylej/tmx/pull/58 is kinda hard to understand because it seens like baylej forced pushed on your commit, instead of creating a new one.

But I think you intended to tmx_load_buffer_path to acts like tmx_rcmgr_load_buffer_vpath is acting but without the definition of an resource manager. Due to this, it is impossible for the current function tmx_load_buffer_path to find files in a path of a given fileName.

The tests shows that to use this method correctly as it is, without defining the resource manager, the user must control the current directory that is loading. I don't think that is a great deal anyway.

Let me know what you think? 

Was that your idea?
Is this implementation okay?
Do you think we should handle the resource_manager somehow? 

- [x] Implementation
- [x] Test
- [ ] Example?
- [ ] Update README

closes #4  ?
